### PR TITLE
GDAES-2743 - Changing pcre to download from Artifactory instead of SourceForge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.6
+
+* Changed custom_pcre.rb to point to Artifactory instead of SourceForge for pcre 8.37
+
 ## 0.3.5
 
 * Made EC2 detection stricter

--- a/attributes/custom_pcre.rb
+++ b/attributes/custom_pcre.rb
@@ -21,5 +21,5 @@
 #
 
 default['openresty']['pcre']['version']  = '8.37'
-default['openresty']['pcre']['url']      = "http://downloads.sourceforge.net/project/pcre/pcre/#{node['openresty']['pcre']['version']}/pcre-#{node['openresty']['pcre']['version']}.tar.bz2"
-default['openresty']['pcre']['checksum'] = '51679ea8006ce31379fb0860e46dd86665d864b5020fc9cd19e71260eef4789d'
+default['openresty']['pcre']['url']      = "http://artifactory-scalr.tools.gannettdigital.com/artifactory/binaries/pcre/pcre-#{node['openresty']['pcre']['version']}.tar.bz2"
+default['openresty']['pcre']['checksum'] = '4c629b3f582366fae4e8912f0d9fa3140347d6e7'


### PR DESCRIPTION
GDAES-2743 - Changing pcre to download from Artifactory instead of SourceForge